### PR TITLE
include properties for tiles in object layers

### DIFF
--- a/src/tiled.lisp
+++ b/src/tiled.lisp
@@ -882,6 +882,7 @@ Only used by the staggered and hexagonal maps."
         :x x
         :y y
         :rotation (or rotation 0)
+        :properties properties
         :visible visible))
       (image
        (make-instance


### PR DESCRIPTION
Hi,

It looks like tile objects in object layers were not getting any properties. You can test this by creating custom properties for any tile object in an object layer and then loading the map with cl-tiled. This change fixes this problem for me.