### PR TITLE
Fixed spelling of isometric from isonometric which prevented isometri…

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Current:
 
 Planned:
 
-* Defining API for isonometric, staggred, and hexagonal maps
+* Defining API for isometric, staggred, and hexagonal maps
 * Make the library more efficient
 * Modifying map and writing TMX/TSX and JSON files (if enough demand for this)
 

--- a/src/tiled-data.lisp
+++ b/src/tiled-data.lisp
@@ -201,7 +201,7 @@
   (layers () :type list))
 
 (deftype torientation ()
-  '(member :orthogonal :isonometric :staggered :hexagonal))
+  '(member :orthogonal :isometric :staggered :hexagonal))
 
 (deftype trender-order ()
   '(member :right-down :right-up :left-down :left-up))
@@ -301,7 +301,7 @@
   (eswitch (orientation :test 'equalp)
     (nil nil)
     ("orthogonal" :orthogonal)
-    ("isonometric" :isonometric)
+    ("isometric" :isometric)
     ("staggered" :staggered)
     ("hexagonal" :hexagonal)))
 

--- a/src/tiled.lisp
+++ b/src/tiled.lisp
@@ -578,7 +578,7 @@ These coordinates are relative to the x and y of the object"
 
 (deftype orientation ()
   "Orientation of the map"
-  '(member :orthogonal :isonometric :staggered :hexagonal))
+  '(member :orthogonal :isometric :staggered :hexagonal))
 
 (deftype render-order ()
   '(member :right-down :right-up :left-down :left-up))


### PR DESCRIPTION
…c maps from loading.

isometric was misspelled in several places. This PR fixes it.