### PR TITLE
Added properties reader to exports.

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -38,6 +38,7 @@
    #:tiled-color-a
 
    #:properties-mixin
+   #:properties
 
    #:tiled-image
    #:image-transparent-color


### PR DESCRIPTION
Exports the properties reader so the slot can be read without having to use ```slot-value```.