### PR TITLE
Fixed the default value of rotation slots to be 0.0 instead of 0 sinc…

### DIFF
--- a/src/tiled.lisp
+++ b/src/tiled.lisp
@@ -806,7 +806,7 @@ Only used by the staggered and hexagonal maps."
         :type type
         :x x
         :y y
-        :rotation (or rotation 0)
+        :rotation (or rotation 0.0)
         :visible visible
         :rx width
         :ry height
@@ -821,7 +821,7 @@ Only used by the staggered and hexagonal maps."
           :type type
           :x x
           :y y
-          :rotation (or rotation 0)
+          :rotation (or rotation 0.0)
           :visible visible
           :vertices
           (mapcar
@@ -839,7 +839,7 @@ Only used by the staggered and hexagonal maps."
           :type type
           :x x
           :y y
-          :rotation (or rotation 0)
+          :rotation (or rotation 0.0)
           :visible visible
           :points (mapcar
                    (lambda (tpoint)
@@ -858,7 +858,7 @@ Only used by the staggered and hexagonal maps."
           :type type
           :x x
           :y y
-          :rotation (or rotation 0)
+          :rotation (or rotation 0.0)
           :visible visible
           :string (or text "")
           :font-family (or font-family "sans-serif")
@@ -881,7 +881,7 @@ Only used by the staggered and hexagonal maps."
         :type type
         :x x
         :y y
-        :rotation (or rotation 0)
+        :rotation (or rotation 0.0)
         :properties properties
         :visible visible))
       (image
@@ -892,7 +892,7 @@ Only used by the staggered and hexagonal maps."
         :type type
         :x x
         :y y
-        :rotation (or rotation 0)
+        :rotation (or rotation 0.0)
         :visible visible
         :image (%load-image image)
         :properties properties))
@@ -904,7 +904,7 @@ Only used by the staggered and hexagonal maps."
         :type type
         :x x
         :y y
-        :rotation (or rotation 0)
+        :rotation (or rotation 0.0)
         :visible visible
         :width width
         :height height


### PR DESCRIPTION
…e the slots are declared to be type float.


The rotation slots are declared to by type float but are initialized to ```0``` when making instances in ```%load-object```. This was causing some trouble when I was testing things on a few different CL implementations (I don't remember which one flagged the issue, might have been CCL).