### PR TITLE
Fixed type of probability slot of tiled-tileset-tile to (or null real…

### DIFF
--- a/src/tiled.lisp
+++ b/src/tiled.lisp
@@ -129,7 +129,7 @@ If nil, indicates no terrain at that corner."
     :reader tile-terrains)
    (probability
     :documentation "'A percentage indicating the probability that this tile is chosen when it competes with others while editing with the terrain tool.'"
-    :type real
+    :type (or null real)
     :initarg :probability
     :reader tile-probability)
    (object-group


### PR DESCRIPTION
…) to reconcile type with the ttileset-tile struct.

At the present time, the probability slot of the struct ```ttileset-tile``` is just copied over when making instances of ```tiled-tileset-tile``` and ```animated-tile``` (see lines https://github.com/Zulu-Inuoe/cl-tiled/blob/2b8731e530bb3cafe2200b6ef070546c22eca14c/src/tiled.lisp#L1070 and https://github.com/Zulu-Inuoe/cl-tiled/blob/2b8731e530bb3cafe2200b6ef070546c22eca14c/src/tiled.lisp#L1076), but the types of the slots are incompatible.

```tiled-tileset-tile`` and ```animated-tile``` use ```real``` (https://github.com/Zulu-Inuoe/cl-tiled/blob/2b8731e530bb3cafe2200b6ef070546c22eca14c/src/tiled.lisp#L132)

but ```ttileset-tile``` uses ```(or null real)``` (https://github.com/Zulu-Inuoe/cl-tiled/blob/2b8731e530bb3cafe2200b6ef070546c22eca14c/src/tiled-data.lisp#L137).

This PR reconciles to two by changing the type of the slot for ```tiled-tileset-tile``` (```animated-tile``` inherits from it) to ```(or null real)```. It could of course be reconciled the other way, though that seemed like it required more changes (I could be wrong on this).