### PR TITLE
Fixed tye of tile slot of tiled-terrain since tmx files can list tid …

### DIFF
--- a/src/tiled.lisp
+++ b/src/tiled.lisp
@@ -205,7 +205,7 @@ The `tile' here refers to the image to be displayed on this particular frame."))
     :reader terrain-name)
    (tile
     :documentation "The tile this terrain type refers to"
-    :type tiled-tile
+    :type (or null tiled-tile)
     :initarg :tile
     :reader terrain-tile)))
 


### PR DESCRIPTION
…0 which means the slot get set to nil.

For terrain, the tile property can be set to 0 in TMX files. Since tile id of 0 is the null tile and is represented by ```nil``` in cl-tiled, this means that such terrains get the ```tile``` slot of ```tiled-terrain``` set to something incompatible since it currently lists its type as ```tiled-tile``` (https://github.com/Zulu-Inuoe/cl-tiled/blob/2b8731e530bb3cafe2200b6ef070546c22eca14c/src/tiled.lisp#L208).


This PR changes the type of the slot to ```(or null tiled-tile)``` to reconcile it.