### PR TITLE
fix tile layers y value

### DIFF
--- a/src/tiled.lisp
+++ b/src/tiled.lisp
@@ -376,7 +376,7 @@ The `tile' here refers to the image to be displayed on this particular frame."))
      (layer-tile-width (cell-layer cell))))
 
 (defun cell-y (cell)
-  (* (cell-row cell)
+  (* (1+ (cell-row cell))
      (layer-tile-height (cell-layer cell))))
 
 (defun cell-full-offsets (cell)


### PR DESCRIPTION
Tiled specifies an object's position by its bottom left point, relative to the top left of the map. So a 32x32 object at the top left of the map would be at position `0,32`. Tiled's format doesn't specify the position of each tile in a tile layer, but cl-tiled's `cell-y` function still seems wrong to me, as calling `cell-y` on the top left tile returns `0` but calling `object-y` on an object positioned directly over it gives `32`. This PR aligns `cell-y` and `object-y`.