### PR TITLE
Export properties and properties-mixin from cl-tiled.data-types

### DIFF
--- a/src/data-types.lisp
+++ b/src/data-types.lisp
@@ -397,7 +397,10 @@
 2 - bottom left
 3 - bottom right
 If nil, indicates no terrain at that corner."
-    :type (simple-array (or null tiled-terrain) 4)
+    ;; For some reason, CCL throws a bad-slot-type error when
+    ;; setting this slot's value if there is a length specified
+    :type #-ccl (simple-array (or null tiled-terrain) 4)
+	  #+ccl (simple-array (or null tiled-terrain) *)
     :initarg :terrains
     :reader tile-terrains)
    (probability

--- a/src/data-types.lisp
+++ b/src/data-types.lisp
@@ -10,6 +10,9 @@
    #:tiled-color-g
    #:tiled-color-b
    #:make-tiled-color
+   
+   #:properties-mixin
+   #:properties
 
    #:property-type
    #:property-name

--- a/src/data-types.lisp
+++ b/src/data-types.lisp
@@ -397,10 +397,7 @@
 2 - bottom left
 3 - bottom right
 If nil, indicates no terrain at that corner."
-    ;; For some reason, CCL throws a bad-slot-type error when
-    ;; setting this slot's value if there is a length specified
-    :type #-ccl (simple-array (or null tiled-terrain) 4)
-	  #+ccl (simple-array (or null tiled-terrain) *)
+    :type (simple-array (or null tiled-terrain) (4))
     :initarg :terrains
     :reader tile-terrains)
    (probability

--- a/src/tiled.lisp
+++ b/src/tiled.lisp
@@ -334,7 +334,7 @@
 
   ;; Sort by y coordinate when :top-down
   (when (eq (object-group-draw-order object-layer) :top-down)
-    (with-slots (objects) object-layer
+    (with-slots ((objects cl-tiled.data-types::objects)) object-layer
       (setf objects (sort objects #'< :key #'object-y))))
   (values))
 


### PR DESCRIPTION
The symbols properties-mixin and properties were exported from the cl-tiled package, but were not exported from cl-tiled.data-types, where they were defined.  Thus, a user could encounter errors trying to read properties, e.g., from an object.  This commit fixes the potential errors by exporting properties-mixin and properties from cl-tiled.data-types.