### PR TITLE
fix bug in %find-tile

### DIFF
--- a/src/tiled.lisp
+++ b/src/tiled.lisp
@@ -270,7 +270,7 @@
   (loop
     :for tileset :in tilesets
     :for tlid := (- tgid (tileset-first-gid tileset))
-    :if (<= 0 tlid (tileset-tile-count tileset))
+    :if (<= 0 tlid (1- (tileset-tile-count tileset)))
       :return
       (let ((tile (find tlid (tileset-tiles tileset) :key #'tile-id)))
         (unless tile


### PR DESCRIPTION
Hello! First off, awesome library and thanks for all your work!

I noticed in using this library when I tried to load a map, some cells were reporting the wrong image source. I think I've tracked this down to an off-by-one bug in the `cl-tiled:%find-tile` function. This PR should fix and I now see the right image source for the cells in the map.

To see the bug in action, you can clone the Github repository dan-passaro/tiledtest which demonstrates the library showing the incorrect image source for a small test map.