### PR TITLE
add repeat-x and repeat-y attrs to image layers

### DIFF
--- a/src/data-types.lisp
+++ b/src/data-types.lisp
@@ -10,7 +10,7 @@
    #:tiled-color-g
    #:tiled-color-b
    #:make-tiled-color
-   
+
    #:properties-mixin
    #:properties
 
@@ -101,6 +101,8 @@
    #:layer-visible
    #:layer-offset-x
    #:layer-offset-y
+   #:layer-repeat-x
+   #:layer-repeat-y
    #:layer-tile-width
    #:layer-tile-height
 
@@ -894,7 +896,17 @@ These coordinates are relative to the x and y of the object"
     :documentation "The image displayed by this layer."
     :type tiled-image
     :initarg :image
-    :reader layer-image)))
+    :reader layer-image)
+   (repeat-x
+    :documentation "The image repeats horizontally."
+    :type boolean
+    :initarg :repeat-x
+    :reader layer-repeat-x)
+   (repeat-y
+    :documentation "The image repeats vertically."
+    :type boolean
+    :initarg :repeat-y
+    :reader layer-repeat-y)))
 
 (defclass group-layer (layer)
   ((layers

--- a/src/impl.lisp
+++ b/src/impl.lisp
@@ -132,6 +132,8 @@
 
    #:timage-layer
    #:timage-layer-image
+   #:timage-layer-repeat-x
+   #:timage-layer-repeat-y
    #:make-timage-layer
 
    #:tlayer-group
@@ -289,7 +291,9 @@
   (tile-data nil :type ttile-data))
 
 (defstruct (timage-layer (:include tlayer))
-  (image nil :type (or null tiled-image)))
+  (image nil :type (or null tiled-image))
+  (repeat-x nil :type boolean)
+  (repeat-y nil :type boolean))
 
 (defstruct (tlayer-group (:include tlayer))
   (layers () :type list))

--- a/src/tiled-json.lisp
+++ b/src/tiled-json.lisp
@@ -232,6 +232,8 @@
    :visible (json-attr-bool image-layer :visible t)
    :offset-x (json-attr-int image-layer :offsetx 0)
    :offset-y (json-attr-int image-layer :offsety 0)
+   :repeat-x (json-attr-bool image-layer :repeatx nil)
+   :repeat-y (json-attr-bool image-layer :repeaty nil)
    :properties (%parse-json-properties (json-child image-layer :properties) (json-child image-layer :propertytypes))
    :image (%parse-json-image (json-attr image-layer :image))))
 

--- a/src/tiled-xml.lisp
+++ b/src/tiled-xml.lisp
@@ -301,6 +301,8 @@
    :visible (xml-attr-bool image-layer "visible" t)
    :offset-x (xml-attr-int image-layer "offsetx" 0)
    :offset-y (xml-attr-int image-layer "offsety" 0)
+   :repeat-x (xml-attr-bool image-layer "repeatx" nil)
+   :repeat-y (xml-attr-bool image-layer "repeaty" nil)
    :properties (%parse-xml-properties (xml-child image-layer "properties"))
    :image (%parse-xml-image (xml-child image-layer "image"))))
 

--- a/src/tiled.lisp
+++ b/src/tiled.lisp
@@ -108,6 +108,8 @@
    #:layer-visible
    #:layer-offset-x
    #:layer-offset-y
+   #:layer-repeat-x
+   #:layer-repeat-y
    #:layer-tile-width
    #:layer-tile-height
 
@@ -481,6 +483,8 @@
    :visible (tlayer-visible tlayer)
    :offset-x (tlayer-offset-x tlayer)
    :offset-y (tlayer-offset-y tlayer)
+   :repeat-x (timage-layer-repeat-x tlayer)
+   :repeat-y (timage-layer-repeat-y tlayer)
    :image (timage-layer-image tlayer)
    :properties (tlayer-properties tlayer)))
 


### PR DESCRIPTION
This PR will allow the "Repeat X" and "Repeat Y" properties of image layers to be accessible using cl-tiled.