### PR TITLE
Added support for class properties; closes #29

### DIFF
--- a/src/data-types.lisp
+++ b/src/data-types.lisp
@@ -25,6 +25,7 @@
    #:bool-property
    #:color-property
    #:file-property
+   #:class-property
 
    #:tiled-image
    #:image-transparent-color
@@ -221,7 +222,7 @@
   (a #xFF :type (unsigned-byte 8)))
 
 (deftype property-type ()
-  '(member :string :int :float :bool :color :file))
+  '(member :string :int :float :bool :color :file :class))
 
 (defgeneric property-name (property)
   (:documentation "The name of the given property."))
@@ -282,6 +283,12 @@
     :reader property-value
     :initarg :value)))
 
+(defclass class-property (property properties-mixin)
+  ())
+
+(defmethod property-value ((property class-property))
+  (properties property))
+
 (defgeneric property-type (property)
   (:documentation "The `property-type' of the given `property'.")
   (:method ((property string-property))
@@ -293,7 +300,9 @@
   (:method ((property color-property))
     :color)
   (:method ((property file-property))
-    :file))
+    :file)
+  (:method ((property class-property))
+    :class))
 
 (defclass tiled-image ()
   ((transparent-color

--- a/src/impl.lisp
+++ b/src/impl.lisp
@@ -346,7 +346,7 @@
     (t
      default)))
 
-(defun make-property (name type value)
+(defun make-property (name type value parse-properties)
   (eswitch (type :test 'string-equal)
     (""
      (make-instance 'string-property :name name :string value))
@@ -366,7 +366,10 @@
      ;; quite difficult.
      ;; This is generally The Right Thing
      (make-instance 'file-property :name name :string value
-                                   :value (uiop:merge-pathnames* value *default-pathname-defaults*)))))
+                                   :value (uiop:merge-pathnames* value *default-pathname-defaults*)))
+    ("class"
+     (make-instance 'class-property :name name :string ""
+                                    :properties (funcall parse-properties value)))))
 
 (defun parse-image-encoding-string (encoding)
   (eswitch (encoding :test 'equalp)

--- a/src/tiled-json.lisp
+++ b/src/tiled-json.lisp
@@ -59,6 +59,8 @@
     (t (list))))
 
 (defun %parse-json-properties (properties property-types)
+  ;; TODO : class properties wouldn't be loaded since there is no
+  ;; propertytypes in Tiled >= 1.2
   (if (and properties property-types)
       (loop
         :for (prop-name . prop-value) :in properties
@@ -67,7 +69,8 @@
         (make-property
          (or (and prop-name (symbol-name prop-name)) "")
          (or prop-type "")
-         (or prop-value "")))
+         (or prop-value "")
+         #'%parse-json-properties))
       (list)))
 
 (defun %parse-json-image (image)

--- a/src/tiled-xml.lisp
+++ b/src/tiled-xml.lisp
@@ -57,9 +57,12 @@
    (xml-attr property "name" "")
    (xml-attr property "type" "")
    ;;Value might be stored in the 'value' property or in the string content
+   ;;or in the <properties> sub-tag for class properties
    (or (xmls:xmlrep-attrib-value "value" property nil)
        (xmls:xmlrep-string-child property nil)
-       "")))
+       (xml-child property "properties")
+       "")
+   #'%parse-xml-properties))
 
 (defun %parse-xml-properties (properties)
   (if properties


### PR DESCRIPTION
Hey @Zulu-Inuoe! This PR adds support for custom class properties [introduced](https://doc.mapeditor.org/en/stable/manual/custom-properties/#custom-types) in Tiled 1.8; custom enum properties also introduced there would work just as regular string values.

There's a small caveat with version compatibility: the JSON loading code is still incompatible with Tiled versions greater than 1.2 (#23 mentions that). I've modified the `make-property` function to take properties loading function as its last argument since the custom classes are in a sense recursive (the class property itself is basically a separate set of properties with a name); but the JSON loading code would never go that path since it is incompatible with versions >= 1.2 and custom properties appeared in 1.8. I've left a comment about that in the code, hope it is enough of documentation :)

Let me know if there's I should add or change in this PR.