### PR TITLE
Set up properties for `polygon-object`s and `polyline-object`s

### DIFF
--- a/src/tiled.lisp
+++ b/src/tiled.lisp
@@ -381,7 +381,8 @@
         :y y
         :rotation (or rotation 0.0)
         :visible visible
-        :vertices (tpolygon-points polygon)))
+        :vertices (tpolygon-points polygon)
+        :properties properties))
       (polyline
        (make-instance
         'polyline-object
@@ -392,7 +393,8 @@
         :y y
         :rotation (or rotation 0.0)
         :visible visible
-        :points (tpolyline-points polyline)))
+        :points (tpolyline-points polyline)
+        :properties properties))
       (text
        (make-instance
         'text-object


### PR DESCRIPTION
Hello! I found that the properties of Tiled's polygon objects and polyline objects are empty in `cl-tiled`. This PR fixes the issue to load them correctly.