### PR TITLE
Fix loading property-less classes

### DIFF
--- a/src/tiled-xml.lisp
+++ b/src/tiled-xml.lisp
@@ -66,7 +66,7 @@
    #'%parse-xml-properties))
 
 (defun %parse-xml-properties (properties)
-  (if properties
+  (if (and properties (not (equal properties "")))
       (mapcar #'%parse-xml-property
               (xml-children properties "property"))
       (list)))


### PR DESCRIPTION
Hey! This tiny PR extends #30 by fixing loading objects of property-less classes, which is allowed by Tiled, as this test map shows: [testmap.zip](https://github.com/user-attachments/files/16988802/testmap.zip)