### PR TITLE
Properly handle external files when calling load-map with relative path

### DIFF
--- a/src/impl.lisp
+++ b/src/impl.lisp
@@ -377,7 +377,7 @@
      ;; quite difficult.
      ;; This is generally The Right Thing
      (make-instance 'file-property :name name :string value
-                                   :value (uiop:merge-pathnames* value *default-pathname-defaults*)))
+                                   :value (uiop:merge-pathnames* value)))
     ("class"
      (make-instance 'class-property :name name :string ""
                                     :properties (funcall parse-properties value)))))


### PR DESCRIPTION
Hey! Making cl-tiled nicely process relative paths turned out to be easier than I anticipated; all puzzle pieces were in place, it just needed a slight rearrangement to work perfectly 😊

Here's the summary of changes:

* in `make-property`, removed `*default-pathname-defaults*` parameter from `uiop:merge-pathnames*` call for clarity, since it is [the default](https://github.com/fare/asdf/blob/f2ded94075a2e6e0b65e66870cf338d1951683e0/uiop/pathname.lisp#L124).
* in `%parse-json-image`, replaced `uiop:ensure-absolute-pathname` call to build image path with `uiop:merge-pathnames*` since now the whole machinery relies on `*default-pathname-defaults*` being set upstream.
* `for-json-tree-from-stream` accommodated for the case of `current-directory` being `nil` (see below), in which it does not change current directory nor `*default-pathname-defaults*`.
* in public functions `parse-json-map-stream`, `parse-json-tileset-stream` and `parse-json-template-stream` the `current-directory` parameter is now optional, to be set by users; internal machinery calling those functions omit the paremeter, leading to `*default-pathname-defaults*` being untouched.
* in `%parse-xml-image`, replaced `uiop:ensure-absolute-pathname` call with `uiop:merge-pathnames*` for the reasons similar to `%parse-json-image`.
* in `%parse-xml-template`, fixed case of `<tileset>` tag being missing from the template file (that's possible according to [documentation](https://doc.mapeditor.org/en/stable/reference/tmx-map-format/#tmx-template-files): it says "at most one `<tileset>`"). This is not directly related to relative paths, but I didn't want to bother you with another single-line pull request 😅
* `%slurp-file` helper removed since it is now not used anywhere (has been for a while).
* added `for-xml-tree-from-stream` helper similar in spirit to `for-json-tree-from-stream`, to deduplicate some code. It also handles the case of unset `current-directory` by not touching `*default-pathname-defaults*`.
* `parse-xml-map-stream`, `parse-xml-tileset-stream` and `parse-xml-template-stream` now take `current-directory` as optional parameter, allowing internal machinery to leave `*default-pathname-defaults*` be as it is, while allowing users to set the current dir as they see fit — just like their JSON counterparts.
* `%load-map` now does not take `path` parameter since all path manipulations now happen upstream, in `load-map`.
* the gist of this PR is `load-map` handling paths slightly differently. It now calls supplied `resource-loader` first (deduplicating the code a bit), then changes both current directory and `*default-pathname-defaults*` to the path where the map resides with the call to `uiop:with-pathname-defaults`, whether that path is relative or absolute (note that CL standard does not mandate that `*default-pathname-defaults*` should be absolute, but SBCL sometimes likes to bark warnings in the case of it being relative). This way, default resource loader, `alexandria:read-file-into-string`, being sophisticated wrapper on `open`, implicitly opens files from the correct directory (since paths written in map file are relative to the directory where the map resides), and user-supplied resource loaders could just explicitly read the value of `*default-pathname-defaults*`. The rest of the function is similar to its previous version.
* public function `load-tileset` now takes optional `resource-loader` parameter as well, defaulting to `read-file-into-string` too.
* `%load-object-layer` now take `resource-loader` parameter since it needs to pass it to `%load-objects` (see below).
* `%load-template` now does not do any current directory/`*default-pathname-defaults*` manipulations, relying to those being set correctly upstream, by `load-map`.
* `%load-cached-template` now takes `resource-loader` parameter instead of hardcoding passing `read-file-into-string` to `%load-template`.
* public `load-template` function now takes optional `resource-loader` parameter instead of hardcoding one as well.
* `%load-object` now needs to take extra `resource-loader` parameter to pass one to `%load-cached-template`.
* `%load-objects` also needs to take `resource-loader` parameter to pass to `%load-object`.
* `%load-layer-group` also takes `resource-loader` parameter, to pass to `%load-object-layer` and itself.
* `%load-embedded-tileset` needs to take extra `resource-loader` parameter too, to pass to `%finalize-tiles` (see below).
* `%load-external-tileset` now does not do any `*default-pathname-defaults*` manipulations as well; the `source` slot of the constructed object is now built using `uiop:merge-pathnames*`, again relying on `*default-pathname-defaults*` being set in `load-map`. It also handles additional JSON tileset extension, `.tsj`.
* finally, `%finalize-tiles` now also needs to take additional `resource-loader` parameter to supply it to `%load-objects`.

I've tested those changes with different cases (map from absolute path, XML and JSON maps from relative path with external tilesets and templates, tilesets and images in different directories), and every case now works perfectly.

Also, for the sake of completeness, loading map from ZIP archive I've mentioned in #34 would look like this:
```
(cl-tiled:load-map "tiled-master/examples/desert.tmx"
                    (lambda (path &rest rest)
                      (declare (ignore rest))
                      (alexandria:read-stream-content-into-string
                       (al:make-character-stream
                        (if (string= (pathname-type path) "tmx")
                            path
                            (uiop:merge-pathnames* path))))))
```
(it it slightly more complex since we want to use the relative path to the map itself literally, as we passed it to `load-map`, but all other file paths are relative to the map path, hence the conditional call to `uiop:merge-pathnames*`).

Let me know if I can improve something further here.