### PR TITLE
Added tile-gid helper

### DIFF
--- a/src/data-types.lisp
+++ b/src/data-types.lisp
@@ -46,6 +46,7 @@
    #:tiled-tile
    #:tile-tileset
    #:tile-id
+   #:tile-gid
    #:tile-column
    #:tile-row
    #:tile-pixel-x
@@ -391,6 +392,12 @@
     :reader tile-id))
   (:documentation
    "A simple tile belonging to a tileset, with no individual properties."))
+
+
+(defun tile-gid (tile)
+  "Get global tile ID, unique within the map."
+  (+ (tile-id tile)
+     (tileset-first-gid (tile-tileset tile))))
 
 (defgeneric tile-image (tile)
   (:method ((tile tiled-tile))

--- a/src/tiled.lisp
+++ b/src/tiled.lisp
@@ -55,6 +55,7 @@
    #:tiled-tile
    #:tile-tileset
    #:tile-id
+   #:tile-gid
    #:tile-column
    #:tile-row
    #:tile-pixel-x


### PR DESCRIPTION
Hey! This tiny PR adds a helper to get global tile ID, `TILE-GID`. I found myself reimplementing it over and over again in every project, and thought it might as well belong to the library 🙂 
I might've missed some function already present with the same functionality though, let me know if that is the case 😅 