### PR TITLE
Fixed type mismatch loading tile objects

### DIFF
--- a/src/data-types.lisp
+++ b/src/data-types.lisp
@@ -805,7 +805,7 @@ These coordinates are relative to the x and y of the object"
 (defclass tile-object (object)
   ((tile
     :documentation "The tile used by this object."
-    :type tiled-tile
+    :type (or null tiled-tile)
     :initarg :tile
     :reader object-tile)
    (width


### PR DESCRIPTION
Hey! This tiny PR fixes SBCL warning that got thrown on high SAFETY settings when loading tile objects (it's been reported [here](https://www.reddit.com/r/Common_Lisp/comments/1g7vem4/workflow_on_how_to_use_the_sbcl_debugger/)).